### PR TITLE
Loop on fetch to get up to 1000 rows

### DIFF
--- a/src/ls/wsjsapi.js
+++ b/src/ls/wsjsapi.js
@@ -479,16 +479,13 @@ var Exasol = function(url, user, pass, onconnect, onerror) {
         context.connection.send(reqdata);
     };
 
-    context.fetch = function(res, startPosition, numBytes, onResponse, onerror) {
+    context.fetch = function(resultSetHandle, startPosition, numBytes, onresponse, onerror) {
         context.com({'command': 'fetch',
-                     'resultSetHandle': +res.resultSetHandle,
+                     'resultSetHandle': +resultSetHandle,
                      'startPosition': +startPosition,
                      'numBytes': +numBytes},
-                    function(rep) {
-                        res.data = rep.data;
-                        res.numRowsInMessage = rep.numRows;
-                        onResponse(res);
-                    }, onerror || context.onerror);
+                    onresponse,
+                    onerror || context.onerror);
     };
 
     context.inwork = false;


### PR DESCRIPTION
- Fix pagination (single page)
- Add types for returned values

Query returning over 1000 rows:
![Screenshot 2021-03-25 at 13 33 25](https://user-images.githubusercontent.com/4571256/112473549-cd95d600-8d6e-11eb-9f19-93f8d9b5448b.png)
![Screenshot 2021-03-25 at 13 33 30](https://user-images.githubusercontent.com/4571256/112473550-ce2e6c80-8d6e-11eb-933e-f1f6526a12a2.png)

Under 1000:
![Screenshot 2021-03-25 at 13 33 37](https://user-images.githubusercontent.com/4571256/112473632-e43c2d00-8d6e-11eb-949c-5bbd4a337cf1.png)
![Screenshot 2021-03-25 at 13 33 40](https://user-images.githubusercontent.com/4571256/112473635-e4d4c380-8d6e-11eb-9db3-b305427e84f9.png)


Note that some queries might return more than 1000 rows in a single message, in which case all are displayed (no change here)