### PR TITLE
Fix large fetches, switch away from batch execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 
 ## 0.0.7
 
-Fix websocket max message size leading to broken fetches, switch away from batch mode
+Fix websocket max message size leading to broken fetches
+Switch away from batch mode
+Always show full schema
+Fix issue with global connection state
 
 ## 0.0.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+
+## 0.0.7
+
+Fix websocket max message size leading to broken fetches, switch away from batch mode
+
 ## 0.0.6
 
 Fix pagination, fetch up to 1000 records from queries

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "exasol-driver",
   "displayName": "Exasol Driver",
   "description": "Exasol Driver for SQLTools",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "vscode": "^1.42.0"
   },

--- a/src/ls/wsjsapi.js
+++ b/src/ls/wsjsapi.js
@@ -302,7 +302,7 @@ var json_parse = (function () {
     };
 }());
 
-var Exasol = function(url, user, pass, onconnect, onerror) {
+var Exasol = function(url, user, pass, onconnect, onerror, websocketConfig) {
     var context = this;
     context.onerror = onerror;
     context.sessionId = "-1";
@@ -489,7 +489,7 @@ var Exasol = function(url, user, pass, onconnect, onerror) {
     };
 
     context.inwork = false;
-    context.connection = new WebSocket(url);
+    context.connection = new WebSocket(url, null, null, null, null, websocketConfig);
     context.connection.onerror = function(err) {
         onerror('Error connecting to "' + url + '"');
     };


### PR DESCRIPTION
Our requested fetch size was too close to the default websocket max message, so sometimes it would exceed the limit which results in messages being dropped.

Also, we switch away from batch mode to allow executing some special statements like scripts.